### PR TITLE
Bump version to 5.0.0-SNAPSHOT for XP 8

### DIFF
--- a/.github/workflows/enonic-docgen.yml
+++ b/.github/workflows/enonic-docgen.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - "master"
+      - "4.x"
     paths:
       - 'docs/**'
   workflow_dispatch:

--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           repoUser: ci
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            4.x
 
   release:
     runs-on: ubuntu-latest

--- a/docs/versions.json
+++ b/docs/versions.json
@@ -1,0 +1,6 @@
+{
+  "versions": [
+    { "label": "stable", "checkout": "4.x", "latest": true },
+    { "label": "next", "checkout": "master" }
+  ]
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,4 +6,4 @@ projectName = ga
 appName = com.enonic.app.ga
 xpVersion = 8.0.0-B4
 
-version = 4.0.1-SNAPSHOT
+version = 5.0.0-SNAPSHOT


### PR DESCRIPTION
## Summary
- Branch out the XP 7 maintenance line at `4.x` (pointed at the post-release SNAPSHOT commit `29759ad`, version `4.0.0-SNAPSHOT`)
- Bump master `version` from `4.0.1-SNAPSHOT` → `5.0.0-SNAPSHOT` in `gradle.properties`
- Add `releaseBranch:` block to `.github/workflows/enonic-gradle.yml` listing both `master` and `4.x`
- Add `4.x` to docgen `on.push.branches` in `.github/workflows/enonic-docgen.yml`
- Seed `docs/versions.json` (`stable`→`4.x`, `next`→`master`)

The companion PR against `4.x` adds the matching `releaseBranch:` block so pushes to `4.x` are recognized as release-branch builds (the action reads the branch's own workflow file).

Reference: app-booster `master` vs `1.x` branches.

## Test plan
- [ ] CI is green on this PR
- [ ] After merge, `./gradlew clean build` from master is green
- [ ] After companion `4.x` PR merges, a CI run on `4.x` classifies it as a release branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)