### PR TITLE
Add release-branch CI config for 4.x

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           repoUser: ${{ secrets.ARTIFACTORY_USERNAME }}
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            4.x
 
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Add `releaseBranch:` block to `.github/workflows/enonic-gradle.yml` listing both `master` and `4.x`
- This is required so pushes to `4.x` are recognized as release-branch builds — the action reads `releaseBranch:` from the branch's own workflow file

Companion to the master PR (#144) that branched out the XP 7 maintenance line.

## Test plan
- [ ] CI is green on this PR
- [ ] After merge, a CI run on `4.x` classifies it as a release branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)