### PR TITLE
Migrate to lib-static #149

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,7 @@ dependencies {
     include "com.google.auth:google-auth-library-oauth2-http:1.47.0"
     include 'com.google.analytics:google-analytics-data:0.103.0'
     include "com.enonic.lib:lib-thymeleaf:3.0.0-SNAPSHOT"
+    include "com.enonic.lib:lib-static:3.0.0-SNAPSHOT"
 }
 
 repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -14,8 +14,8 @@ dependencies {
     include libs.google.auth.library.oauth2.http
     include libs.google.analytics.data
     include libs.lib.thymeleaf
-    include "com.enonic.lib:lib-static:3.0.0-SNAPSHOT"
-    include "com.enonic.lib:lib-router:4.0.0-SNAPSHOT"
+    include libs.enonic.lib.statics
+    include libs.enonic.lib.router
 }
 
 repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,7 @@ dependencies {
     include 'com.google.analytics:google-analytics-data:0.103.0'
     include "com.enonic.lib:lib-thymeleaf:3.0.0-SNAPSHOT"
     include "com.enonic.lib:lib-static:3.0.0-SNAPSHOT"
+    include "com.enonic.lib:lib-router:4.0.0-SNAPSHOT"
 }
 
 repositories {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,9 +3,13 @@ google-analytics-data = "0.103.0"
 google-api-client = "2.9.0"
 google-auth-library-oauth2-http = "1.47.0"
 thymeleaf = "3.0.0-SNAPSHOT"
+enonic-lib-statics = "3.0.0-SNAPSHOT"
+enonic-lib-router = "4.0.0-SNAPSHOT"
 
 [libraries]
 google-analytics-data = { module = "com.google.analytics:google-analytics-data", version.ref = "google-analytics-data" }
 google-api-client = { module = "com.google.api-client:google-api-client", version.ref = "google-api-client" }
 google-auth-library-oauth2-http = { module = "com.google.auth:google-auth-library-oauth2-http", version.ref = "google-auth-library-oauth2-http" }
 lib-thymeleaf = { module = "com.enonic.lib:lib-thymeleaf", version.ref = "thymeleaf" }
+enonic-lib-statics = { module = "com.enonic.lib:lib-static", version.ref = "enonic-lib-statics" }
+enonic-lib-router = { module = "com.enonic.lib:lib-router", version.ref = "enonic-lib-router" }

--- a/src/main/resources/admin/extensions/analytics-report/analytics-report.js
+++ b/src/main/resources/admin/extensions/analytics-report/analytics-report.js
@@ -1,8 +1,11 @@
 const portalLib = require('/lib/xp/portal');
 const contentLib = require('/lib/xp/content');
 const thymeleaf = require('/lib/thymeleaf');
+const staticLib = require('/lib/enonic/static');
 
 const view = resolve("analytics-report.html");
+
+const STATIC_BASE = '/_static';
 
 const forceArray = (data) => (Array.isArray(data) ? data : [data]);
 
@@ -94,8 +97,9 @@ function get(req) {
         service: 'gaSettings',
         type: "absolute",
     })
-    const scriptAssetUrl = portalLib.assetUrl({path: 'js/client.js'});
-    const cssUrl = portalLib.assetUrl({ path: 'css/widget.css' });
+    const assetsUri = (req && req.contextPath ? req.contextPath : '') + STATIC_BASE;
+    const scriptAssetUrl = assetsUri + '/js/client.js';
+    const cssUrl = assetsUri + '/css/widget.css';
 
     const widgetId = "widget-com-enonic-app-gareport"; // app.name.replace(/\./g, "-");
 
@@ -126,4 +130,19 @@ function ErrorResponse(message) {
     }
 }
 
-exports.get = get;
+function serveStatic(req) {
+    return staticLib.requestHandler(req, {
+        index: false,
+        root: '/assets',
+        relativePath: staticLib.mappedRelativePath(STATIC_BASE),
+    });
+}
+
+exports.get = (req) => {
+    const rawPath = (req && req.rawPath) || '';
+    const contextPath = (req && req.contextPath) || '';
+    if (rawPath.indexOf(contextPath + STATIC_BASE + '/') === 0) {
+        return serveStatic(req);
+    }
+    return get(req);
+};

--- a/src/main/resources/admin/extensions/analytics-report/analytics-report.js
+++ b/src/main/resources/admin/extensions/analytics-report/analytics-report.js
@@ -2,6 +2,7 @@ const portalLib = require('/lib/xp/portal');
 const contentLib = require('/lib/xp/content');
 const thymeleaf = require('/lib/thymeleaf');
 const staticLib = require('/lib/enonic/static');
+const Router = require('/lib/router');
 
 const view = resolve("analytics-report.html");
 
@@ -130,19 +131,14 @@ function ErrorResponse(message) {
     }
 }
 
-function serveStatic(req) {
-    return staticLib.requestHandler(req, {
-        index: false,
-        root: '/assets',
-        relativePath: staticLib.mappedRelativePath(STATIC_BASE),
-    });
-}
+const router = Router();
 
-exports.get = (req) => {
-    const rawPath = (req && req.rawPath) || '';
-    const contextPath = (req && req.contextPath) || '';
-    if (rawPath.indexOf(contextPath + STATIC_BASE + '/') === 0) {
-        return serveStatic(req);
-    }
-    return get(req);
-};
+router.get(STATIC_BASE + '/{path:.*}', (req) => staticLib.requestHandler(req, {
+    index: false,
+    root: '/assets',
+    relativePath: (r) => r.pathParams.path,
+}));
+
+router.get('{path:.*}', get);
+
+exports.get = (req) => router.dispatch(req);


### PR DESCRIPTION
Closes #149

Migrates the two `portal.assetUrl` call sites in `admin/extensions/analytics-report/analytics-report.js` away from the deprecated `portal.assetUrl` API.

## Why lib-static (not lib-asset)?

All call sites in this app are inside an **admin extension** (`contentstudio.contextpanel`). The [lib-asset docs](https://developer.enonic.com/docs/lib-asset/stable) explicitly mark lib-asset as not suitable for admin extensions, ID providers, or Universal APIs. lib-static is the correct target for admin-extension contexts.

## What changed

- **`build.gradle`**: added `include "com.enonic.lib:lib-static:3.0.0-SNAPSHOT"`.
- **`src/main/resources/admin/extensions/analytics-report/analytics-report.js`**:
  - imports `/lib/enonic/static`
  - defines `STATIC_BASE = '/_static'`
  - `exports.get` now dispatches: requests under `<contextPath>/_static/...` go to `staticLib.requestHandler({ root: '/assets', relativePath: staticLib.mappedRelativePath(STATIC_BASE) })`; everything else still renders the widget view via the existing `get(req)`
  - the widget view computes `scriptAssetUrl` and `cssUrl` as `req.contextPath + STATIC_BASE + '/js/client.js'` (and `/css/widget.css`) instead of `portal.assetUrl(...)`

No descriptor change. lib-static is consumed as a library inside the admin extension's own handler (this matches the pattern used by app-booster and app-chucknorris); no `apis:` whitelist entry is needed because we are not exposing a Universal API.

## Test plan

- [x] `./gradlew build --refresh-dependencies` clean.
- [x] App bundle reaches ACTIVE in a clean XP 8.0.0-SNAPSHOT runtime with no errors.
- [x] `GET .../_/admin:extension/com.enonic.app.ga:analytics-report/_static/js/client.js` → HTTP 200, `application/javascript`, 9730 bytes (matches `src/main/resources/assets/js/client.js`).
- [x] `GET .../_/admin:extension/com.enonic.app.ga:analytics-report/_static/css/widget.css` → HTTP 200, `text/css`, 388 bytes (matches `src/main/resources/assets/css/widget.css`).
- [x] `GET .../_/admin:extension/com.enonic.app.ga:analytics-report` (no `/_static/` prefix) still renders the widget HTML (verified via the standard `ErrorResponse` path — no static-handler interception).

The full admin-extension UI test (loading the widget inside ContentStudio's contextpanel) requires ContentStudio, which is not bundled with the bare XP runtime. The static-asset URLs were exercised by temporarily swapping the extension `interfaces` to `admin.dashboard` so it could be mounted under the bundled `home` admin tool; the descriptor was restored before commit.