### PR TITLE
Introduce TOML version catalog

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,10 +10,10 @@ dependencies {
     implementation xplibs.api.jaxrs
     include xplibs.content
     include xplibs.portal
-    include "com.google.api-client:google-api-client:2.9.0"
-    include "com.google.auth:google-auth-library-oauth2-http:1.47.0"
-    include 'com.google.analytics:google-analytics-data:0.103.0'
-    include "com.enonic.lib:lib-thymeleaf:3.0.0-SNAPSHOT"
+    include libs.google.api.client
+    include libs.google.auth.library.oauth2.http
+    include libs.google.analytics.data
+    include libs.lib.thymeleaf
 }
 
 repositories {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,11 @@
+[versions]
+google-analytics-data = "0.103.0"
+google-api-client = "2.9.0"
+google-auth-library-oauth2-http = "1.47.0"
+thymeleaf = "3.0.0-SNAPSHOT"
+
+[libraries]
+google-analytics-data = { module = "com.google.analytics:google-analytics-data", version.ref = "google-analytics-data" }
+google-api-client = { module = "com.google.api-client:google-api-client", version.ref = "google-api-client" }
+google-auth-library-oauth2-http = { module = "com.google.auth:google-auth-library-oauth2-http", version.ref = "google-auth-library-oauth2-http" }
+lib-thymeleaf = { module = "com.enonic.lib:lib-thymeleaf", version.ref = "thymeleaf" }


### PR DESCRIPTION
## Summary

Move the inline dependency version strings in `build.gradle` to a new Gradle TOML version catalog at `gradle/libs.versions.toml`. Pin-for-pin migration — no version bumps. Resolved runtime classpath is identical before and after (verified via `./gradlew dependencies --configuration runtimeClasspath`).

## Conventions adopted

- Version keys: short, lowercase, hyphen-separated.
- Library keys: same style; `lib-<name>` for Enonic libs to mirror artifact name.
- `[versions]` and `[libraries]` sorted alphabetically.
- `xpVersion` stays in `gradle.properties` (unchanged).
- `xplibs.*` accessors and `com.enonic.xp:*:${xpVersion}` lines untouched (not in scope).

## New catalog

```toml
[versions]
google-analytics-data = "0.103.0"
google-api-client = "2.9.0"
google-auth-library-oauth2-http = "1.47.0"
thymeleaf = "3.0.0-SNAPSHOT"

[libraries]
google-analytics-data = { module = "com.google.analytics:google-analytics-data", version.ref = "google-analytics-data" }
google-api-client = { module = "com.google.api-client:google-api-client", version.ref = "google-api-client" }
google-auth-library-oauth2-http = { module = "com.google.auth:google-auth-library-oauth2-http", version.ref = "google-auth-library-oauth2-http" }
lib-thymeleaf = { module = "com.enonic.lib:lib-thymeleaf", version.ref = "thymeleaf" }
```

## Test plan

- [x] `./gradlew build --refresh-dependencies` green locally
- [x] `./gradlew dependencies --configuration runtimeClasspath` diff is empty between master and this branch