### PR TITLE
Drop version-history clutter from docs #159

### DIFF
--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -2,7 +2,7 @@
 
 This guide will help you set up Google Analytics app for Enonic XP.
 
-IMPORTANT: This integration requires a Google Analytics 4 account and will not support deprecated Universal Analytics.
+IMPORTANT: This integration requires a Google Analytics 4 account.
 
 :toc:
 


### PR DESCRIPTION
Closes #159.

## What changed

Trimmed the "will not support deprecated Universal Analytics" clause from the top-of-doc `IMPORTANT` admonition in `docs/index.adoc`. The remaining sentence keeps the live integration requirement.

```diff
-IMPORTANT: This integration requires a Google Analytics 4 account and will not support deprecated Universal Analytics.
+IMPORTANT: This integration requires a Google Analytics 4 account.
```

## Why

Google fully sunset Universal Analytics in July 2023. Three years on, calling it out in our current setup docs reads as "removed-behavior history" rather than as a live caveat — exactly the kind of clutter the issue is scoped to. The "requires a Google Analytics 4 account" part is the still-useful integration prerequisite (like "requires XP 8+"), so it stays.

## What was deliberately kept

- The two `IMPORTANT:` admonitions on GA4 account requirement and file-access requirement (still current caveats).
- The `TIP:` about installing the app from the Applications tool (still current guidance).
- Everything else — the doc had no `(added in vX.Y)` / `(since X.Y)` annotations, no "Starting from version X…" changelog notes, and no obsolete pre-XP8 references to remove. This is a small, focused cleanup because there wasn't much clutter to begin with.

## Out of scope

- No branch changes.
- No `docs/versions.json` restructuring.
- `4.x` (XP 7 docs) untouched.

## Verification

- AsciiDoc renders cleanly locally (`asciidoc docs/index.adoc`); the `IMPORTANT` admonition still emits.